### PR TITLE
Explicitly use the `main` branch when using degit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Live demo site: https://vite-elm-template.netlify.app/
 
 ```bash
 # Clone the template locally, removing the template's Git log
-npx degit lindsaykwardell/vite-elm-template my-elm-app
+npx degit lindsaykwardell/vite-elm-template#main my-elm-app
 
 # Enter the project, install dependencies, and get started!
 cd my-elm-app


### PR DESCRIPTION
By default, degit expects a `master` branch to exists, if there is none it fails with the following error:

```
! could not find commit hash for master
```

Specifying the `main` branch with `#main` works as expected.