### PR TITLE
fix main.js for running in development mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,11 +2,7 @@ import "./style.css";
 import { Elm } from "./src/Main.elm";
 
 if (process.env.NODE_ENV === "development") {
-    const ElmDebugTransform = await import("elm-debug-transformer")
-
-    ElmDebugTransform.register({
-        simple_mode: true
-    })
+      import("elm-debug-transformer").then((module) => module.register({ simple_mode: true }))
 }
 
 const root = document.querySelector("#app div");


### PR DESCRIPTION
Hello,

I found out that trying out the template in development mode with `npm run dev` did not work, because main.js tries to await a module outside of an async function. I fixed it by replacing await with .then(). Hope this is OK.